### PR TITLE
Add backend unit and regression tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_predict_endpoint.py
+++ b/backend/tests/test_predict_endpoint.py
@@ -1,0 +1,45 @@
+import asyncio
+from io import BytesIO
+
+import pytest
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
+from backend.app.api.endpoints import predict as predict_endpoint
+
+
+class StubPredictor:
+    def __init__(self):
+        self.seen_payload = None
+
+    def predict_image_bytes(self, payload: bytes):
+        self.seen_payload = payload
+        return {
+            "predicted_class": "ripe",
+            "confidence": 0.9,
+            "predicted_index": 1,
+            "class_probabilities": {"ripe": 0.9, "unripe": 0.025, "overripe": 0.025, "rotten": 0.025, "unknowns": 0.025},
+            "expected_days": 4.0,
+            "model_info": {"format": "mock", "img_size": 224, "model_type": "test"},
+        }
+
+
+def test_predict_file_endpoint_returns_augmented_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = StubPredictor()
+
+    monkeypatch.setattr(predict_endpoint, "get_predictor", lambda: stub)
+
+    upload = UploadFile(
+        file=BytesIO(b"binary-image"),
+        filename="banana.jpg",
+        headers=Headers({"content-type": "image/jpeg"}),
+    )
+
+    response = asyncio.run(predict_endpoint.predict_from_file(upload))
+
+    assert response["predicted_class"] == "ripe"
+    assert response["temp_file_data"]["filename"] == "banana.jpg"
+    assert response["temp_file_data"]["content_type"] == "image/jpeg"
+    assert response["temp_file_data"]["content"]
+    assert response["image_key"].startswith("temp_")
+    assert stub.seen_payload == b"binary-image"

--- a/backend/tests/test_predictor_mock_prediction.py
+++ b/backend/tests/test_predictor_mock_prediction.py
@@ -1,0 +1,30 @@
+import pytest
+
+from backend.app.api.services import predictor as predictor_module
+from backend.app.api.services.predictor import PredictorService
+
+
+def test_predict_image_bytes_returns_deterministic_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit test ensuring mock predictions are reproducible when randomness is patched."""
+    predictor = PredictorService()
+
+    monkeypatch.setattr(predictor_module.random, "choice", lambda seq: "ripe")
+    monkeypatch.setattr(predictor_module.random, "uniform", lambda a, b: 0.88)
+
+    result = predictor.predict_image_bytes(b"not-an-image-but-mock-does-not-care")
+
+    assert result["predicted_class"] == "ripe"
+    assert result["confidence"] == pytest.approx(0.88)
+    assert result["predicted_index"] == predictor.class_names.index("ripe")
+
+    # Ensure probabilities sum to 1 and contain the mocked confidence
+    total_prob = sum(result["class_probabilities"].values())
+    assert total_prob == pytest.approx(1.0)
+    assert result["class_probabilities"]["ripe"] == pytest.approx(0.88)
+
+    # Expected days should align with the configured mapping for the class
+    class_to_days = predictor_module.get_class_to_days_mapping()
+    assert result["expected_days"] == pytest.approx(class_to_days["ripe"])
+
+    assert result["model_info"]["format"] == "mock"
+    assert "warning" in result

--- a/backend/tests/test_predictor_utils.py
+++ b/backend/tests/test_predictor_utils.py
@@ -1,0 +1,59 @@
+import math
+
+import pytest
+
+from backend.app.api.services.predictor import (
+    PredictorService,
+    get_days_to_class_thresholds,
+    map_days_left_to_class,
+)
+
+
+@pytest.mark.parametrize(
+    "days_left,expected",
+    [
+        (6.2, "unripe"),
+        (4.2, "ripe"),
+        (1.3, "overripe"),
+        (0.2, "rotten"),
+        (-1.0, "unknowns"),
+    ],
+)
+def test_map_days_left_to_class_matches_thresholds(days_left: float, expected: str) -> None:
+    """Ensure the helper respects the configured thresholds."""
+    assert map_days_left_to_class(days_left) == expected
+
+
+def test_map_days_left_to_class_rounds_before_comparison() -> None:
+    """Rounding should shift borderline values to the correct class."""
+    thresholds = get_days_to_class_thresholds()
+
+    # Slightly below the unripe threshold should round up to unripe
+    almost_unripe = thresholds["unripe_min"] - 0.49
+    assert map_days_left_to_class(almost_unripe) == "unripe"
+
+    # Slightly above the ripe max should round down to ripe
+    almost_ripe = thresholds["ripe_max"] + 0.49
+    assert map_days_left_to_class(almost_ripe) == "ripe"
+
+
+def test_validate_correction_reports_consistency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression test for correction validation consistency reporting."""
+    predictor = PredictorService()
+
+    # Force deterministic mapping by patching helper to a known class
+    monkeypatch.setattr(
+        "backend.app.api.services.predictor.map_days_left_to_class",
+        lambda value: "ripe",
+    )
+
+    validation = predictor.validate_correction(days_left=3.0, user_class="ripe")
+
+    assert validation["suggested_class"] == "ripe"
+    assert validation["is_consistent"] is True
+    assert math.isclose(validation["confidence_score"], 1.0)
+
+    validation_mismatch = predictor.validate_correction(days_left=3.0, user_class="unripe")
+    assert validation_mismatch["suggested_class"] == "ripe"
+    assert validation_mismatch["is_consistent"] is False
+    assert math.isclose(validation_mismatch["confidence_score"], 0.5)


### PR DESCRIPTION
## Summary
- add pytest configuration to import the backend package from repository root
- cover predictor helper logic and correction validation with deterministic unit tests
- add regression test for the predict file endpoint with a stubbed predictor service

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_b_68e43ebb97ec833299c86062c0d0ceed