### PR TITLE
Streamline banana homepage storytelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ logs/
 *.pkl
 
 wandb/
+node_modules/
+frontend/node_modules/

--- a/frontend/src/components/BananaPixelIcon.tsx
+++ b/frontend/src/components/BananaPixelIcon.tsx
@@ -1,0 +1,82 @@
+import { memo } from 'react';
+
+interface BananaPixelIconProps {
+  className?: string;
+  size?: number;
+}
+
+/**
+ * Simple pixel-art banana rendered with SVG rectangles so it can scale nicely.
+ */
+const BananaPixelIconComponent = ({ className = '', size = 64 }: BananaPixelIconProps) => {
+  return (
+    <svg
+      role="img"
+      aria-label="Icône pixel art de banane"
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      className={className}
+    >
+      <defs>
+        <linearGradient id="bananaShine" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#fff3b0" />
+          <stop offset="50%" stopColor="#ffdd57" />
+          <stop offset="100%" stopColor="#f0b429" />
+        </linearGradient>
+      </defs>
+      <rect width="32" height="32" fill="none" />
+      <g fill="#2f1e0c">
+        <rect x="6" y="5" width="2" height="2" />
+        <rect x="7" y="6" width="2" height="2" />
+        <rect x="8" y="7" width="2" height="2" />
+        <rect x="9" y="8" width="2" height="2" />
+      </g>
+      <g fill="url(#bananaShine)">
+        <rect x="9" y="9" width="2" height="2" />
+        <rect x="10" y="10" width="2" height="2" />
+        <rect x="11" y="11" width="2" height="2" />
+        <rect x="12" y="12" width="2" height="2" />
+        <rect x="13" y="13" width="2" height="2" />
+        <rect x="14" y="14" width="2" height="2" />
+        <rect x="15" y="15" width="2" height="2" />
+        <rect x="16" y="16" width="2" height="2" />
+        <rect x="17" y="17" width="2" height="2" />
+        <rect x="18" y="17" width="2" height="2" />
+        <rect x="19" y="16" width="2" height="2" />
+        <rect x="20" y="15" width="2" height="2" />
+        <rect x="21" y="14" width="2" height="2" />
+        <rect x="22" y="13" width="2" height="2" />
+        <rect x="23" y="12" width="2" height="2" />
+        <rect x="24" y="11" width="2" height="2" />
+        <rect x="25" y="10" width="2" height="2" />
+        <rect x="26" y="9" width="2" height="2" />
+        <rect x="24" y="18" width="2" height="2" />
+        <rect x="23" y="19" width="2" height="2" />
+        <rect x="22" y="20" width="2" height="2" />
+        <rect x="21" y="21" width="2" height="2" />
+        <rect x="20" y="22" width="2" height="2" />
+        <rect x="19" y="23" width="2" height="2" />
+        <rect x="18" y="24" width="2" height="2" />
+        <rect x="17" y="25" width="2" height="2" />
+        <rect x="16" y="26" width="2" height="2" />
+      </g>
+      <g fill="#f7b731">
+        <rect x="20" y="18" width="2" height="2" />
+        <rect x="19" y="19" width="2" height="2" />
+        <rect x="18" y="20" width="2" height="2" />
+        <rect x="17" y="21" width="2" height="2" />
+        <rect x="16" y="22" width="2" height="2" />
+        <rect x="15" y="23" width="2" height="2" />
+        <rect x="14" y="24" width="2" height="2" />
+      </g>
+      <g fill="#d17b0f">
+        <rect x="24" y="9" width="2" height="2" />
+        <rect x="25" y="8" width="2" height="2" />
+        <rect x="26" y="7" width="2" height="2" />
+      </g>
+    </svg>
+  );
+};
+
+export const BananaPixelIcon = memo(BananaPixelIconComponent);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useSettings } from '../store/useSettings';
 import { applyTheme } from '../utils/theme';
+import { BananaPixelIcon } from './BananaPixelIcon';
 
 interface LayoutProps {
   children: ReactNode;
@@ -30,26 +31,28 @@ export const Layout = ({ children }: LayoutProps) => {
   ];
 
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-900">
-      <header className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
-            <nav className="flex items-center gap-8" aria-label="Navigation principale">
+    <div className="flex min-h-screen flex-col bg-banana-50 dark:bg-gray-950">
+      <header className="relative border-b border-yellow-200/60 bg-white/90 backdrop-blur dark:border-yellow-500/30 dark:bg-gray-900/80">
+        <div className="absolute inset-x-0 -top-24 mx-auto h-32 w-[90%] max-w-6xl bg-gradient-to-r from-yellow-200/60 via-yellow-100/40 to-yellow-200/60 blur-3xl" aria-hidden="true" />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-20 items-center justify-between">
+            <nav className="flex items-center gap-6" aria-label="Navigation principale">
               <Link
                 to="/"
-                className="text-xl font-bold text-gray-900 dark:text-white"
+                className="flex items-center gap-3 rounded-full bg-white/70 px-4 py-2 text-xl font-bold text-gray-900 shadow-sm ring-1 ring-yellow-300/60 transition hover:-translate-y-0.5 hover:shadow-lg dark:bg-gray-900/60 dark:text-yellow-100 dark:ring-yellow-500/40"
               >
-                🍌 Banana Prediction
+                <BananaPixelIcon size={36} />
+                <span>Banana Prediction</span>
               </Link>
-              <div className="hidden gap-4 sm:flex">
+              <div className="hidden items-center gap-2 rounded-full bg-white/60 px-3 py-1 text-sm shadow-sm ring-1 ring-yellow-200/60 dark:bg-gray-900/60 dark:ring-yellow-500/40 sm:flex">
                 {navLinks.map((link) => (
                   <Link
                     key={link.path}
                     to={link.path}
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    className={`rounded-full px-3 py-1 font-medium transition-all ${
                       location.pathname === link.path
-                        ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
-                        : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+                        ? 'bg-yellow-300 text-gray-900 shadow-sm dark:bg-yellow-500 dark:text-gray-900'
+                        : 'text-gray-700 hover:bg-yellow-200/80 dark:text-yellow-100 dark:hover:bg-yellow-500/40'
                     }`}
                     aria-current={location.pathname === link.path ? 'page' : undefined}
                   >
@@ -60,22 +63,30 @@ export const Layout = ({ children }: LayoutProps) => {
             </nav>
             <button
               onClick={toggleTheme}
-              className="rounded-lg p-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:hover:bg-gray-700"
+              className="flex items-center gap-2 rounded-full bg-white/70 px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 dark:bg-gray-900/70 dark:text-yellow-100 dark:hover:bg-gray-900"
               aria-label={`Thème actuel : ${theme}. Cliquer pour changer`}
             >
               <span className="text-xl" aria-hidden="true">{getThemeIcon()}</span>
+              <span className="hidden sm:inline">Thème</span>
             </button>
           </div>
         </div>
       </header>
 
-      <main className="mx-auto flex-1 max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main className="relative mx-auto flex-1 w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-64 w-[95%] max-w-5xl rounded-[3rem] bg-gradient-to-br from-yellow-200 via-yellow-100 to-yellow-300 opacity-70 blur-3xl dark:from-yellow-500/30 dark:via-yellow-400/20 dark:to-yellow-500/20" aria-hidden="true" />
         {children}
       </main>
 
-      <footer className="border-t border-gray-200 bg-white py-6 dark:border-gray-700 dark:bg-gray-800">
-        <div className="mx-auto max-w-7xl px-4 text-center text-sm text-gray-500 dark:text-gray-400">
-          Banana Prediction App - Prédiction et correction d&apos;images
+      <footer className="border-t border-yellow-200/80 bg-white/90 py-8 text-sm text-gray-600 backdrop-blur dark:border-yellow-500/30 dark:bg-gray-900/80 dark:text-yellow-100">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3 font-medium">
+            <BananaPixelIcon size={28} className="drop-shadow" />
+            <span>Prédiction &amp; correction d&apos;images de bananes</span>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-yellow-200/80">
+            Conçu pour surveiller la maturité des bananes avec une touche de soleil tropical.
+          </p>
         </div>
       </footer>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,7 +10,11 @@
   }
 
   body {
-    @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-white;
+    @apply bg-banana-50 text-gray-900 dark:bg-gray-950 dark:text-white;
+    background-image: radial-gradient(circle at 20% 20%, rgba(255, 243, 196, 0.6), transparent 55%),
+      radial-gradient(circle at 80% 10%, rgba(250, 219, 95, 0.5), transparent 55%),
+      radial-gradient(circle at 50% 80%, rgba(240, 180, 41, 0.35), transparent 60%);
+    background-attachment: fixed;
   }
 
   #root {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { health } from '../api/endpoints';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { Spinner } from '../components/Spinner';
+import { BananaPixelIcon } from '../components/BananaPixelIcon';
 
 export const Home = () => {
   const [status, setStatus] = useState<'loading' | 'online' | 'offline'>('loading');
@@ -23,92 +24,150 @@ export const Home = () => {
   }, []);
 
   return (
-    <div className="space-y-8">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
-          Bienvenue sur Banana Prediction
-        </h1>
-        <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
-          Analysez vos images de bananes et obtenez des prédictions de maturité
-        </p>
-      </div>
-
-      <div className="mx-auto max-w-md">
-        <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
-            État du backend
-          </h2>
-
-          {status === 'loading' && (
-            <div className="flex items-center gap-3">
-              <Spinner size="sm" />
-              <span className="text-gray-600 dark:text-gray-400">Vérification en cours...</span>
+    <div className="flex flex-col gap-12">
+      <section className="relative overflow-hidden rounded-3xl bg-white/80 p-10 shadow-xl ring-1 ring-yellow-200/70 backdrop-blur dark:bg-gray-900/70 dark:ring-yellow-500/30">
+        <div className="absolute -right-12 -top-12 h-48 w-48 rounded-full bg-gradient-to-br from-yellow-200/70 to-yellow-400/60 blur-2xl" aria-hidden="true" />
+        <div className="absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-gradient-to-tr from-yellow-300/70 to-yellow-500/60 blur-2xl" aria-hidden="true" />
+        <div className="relative grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <div className="inline-flex items-center gap-3 rounded-full bg-yellow-100/80 px-4 py-2 text-sm font-medium text-yellow-800 dark:bg-yellow-500/30 dark:text-yellow-100">
+              <BananaPixelIcon size={32} />
+              <span>Banana Prediction, le baromètre de maturité tropical</span>
             </div>
-          )}
-
-          {status === 'online' && (
-            <div className="flex items-center gap-3">
-              <div className="h-3 w-3 rounded-full bg-green-500" aria-hidden="true" />
-              <span className="font-medium text-green-700 dark:text-green-400">En ligne</span>
+            <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl dark:text-yellow-50">
+              Surveillez la vie secrète de vos bananes
+            </h1>
+            <p className="text-lg text-gray-600 dark:text-yellow-100/90">
+              Téléversez vos photos, laissez l&apos;IA analyser la maturité et profitez d&apos;une interface ensoleillée pour suivre, corriger et améliorer vos prédictions de bananes.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                to="/predict"
+                className="inline-flex items-center gap-2 rounded-full bg-yellow-400 px-6 py-3 text-base font-semibold text-gray-900 shadow-lg transition hover:-translate-y-0.5 hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 dark:bg-yellow-500 dark:hover:bg-yellow-400"
+              >
+                Commencer une prédiction
+                <span aria-hidden="true">🍌</span>
+              </Link>
+              <Link
+                to="/settings"
+                className="inline-flex items-center gap-2 rounded-full border border-yellow-300/80 bg-white/70 px-6 py-3 text-base font-semibold text-yellow-700 transition hover:-translate-y-0.5 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 dark:border-yellow-400/60 dark:bg-gray-900/60 dark:text-yellow-100 dark:hover:bg-gray-900"
+              >
+                Paramétrer l&apos;appli
+                <span aria-hidden="true">⚙️</span>
+              </Link>
             </div>
-          )}
-
-          {status === 'offline' && (
-            <div className="space-y-3">
-              <div className="flex items-center gap-3">
-                <div className="h-3 w-3 rounded-full bg-red-500" aria-hidden="true" />
-                <span className="font-medium text-red-700 dark:text-red-400">Hors ligne</span>
+            <div className="flex flex-wrap items-center gap-6 text-sm text-gray-500 dark:text-yellow-100/80">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-yellow-200 text-base">🌞</span>
+                Interface pensée pour la clarté et l&apos;accessibilité
               </div>
-              {error && <ErrorAlert error={error} />}
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-yellow-200 text-base">🔄</span>
+                Boucle de correction continue
+              </div>
             </div>
-          )}
+          </div>
+          <div className="relative rounded-3xl border border-yellow-200/70 bg-gradient-to-br from-yellow-100 via-yellow-200/70 to-yellow-300/80 p-8 text-gray-900 shadow-inner dark:border-yellow-500/30 dark:from-yellow-400/10 dark:via-yellow-500/10 dark:to-yellow-400/20 dark:text-yellow-50">
+            <h2 className="mb-6 flex items-center gap-3 text-xl font-semibold">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-white text-2xl shadow-md dark:bg-gray-950">
+                <BananaPixelIcon size={28} />
+              </span>
+              Thermomètre des bananes
+            </h2>
+            <p className="mb-4 text-sm text-gray-700 dark:text-yellow-100/90">
+              Statut du backend FastAPI qui nourrit nos prédictions.
+            </p>
+            {status === 'loading' && (
+              <div className="flex items-center gap-3 rounded-2xl bg-white/70 px-4 py-3 text-gray-700 shadow-sm dark:bg-gray-900/70 dark:text-yellow-100">
+                <Spinner size="sm" />
+                <span>Vérification en cours...</span>
+              </div>
+            )}
+
+            {status === 'online' && (
+              <div className="flex items-center gap-3 rounded-2xl bg-white/80 px-4 py-3 text-green-700 shadow-sm dark:bg-gray-900/70 dark:text-green-300">
+                <div className="h-3 w-3 rounded-full bg-green-500" aria-hidden="true" />
+                <span className="font-medium">Le service est ensoleillé</span>
+              </div>
+            )}
+
+            {status === 'offline' && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3 rounded-2xl bg-white/90 px-4 py-3 text-red-600 shadow-sm dark:bg-gray-900/70 dark:text-red-300">
+                  <div className="h-3 w-3 rounded-full bg-red-500" aria-hidden="true" />
+                  <span className="font-medium">Oups, la grappe est hors ligne</span>
+                </div>
+                {error && <ErrorAlert error={error} />}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </section>
 
-      <div className="mx-auto grid max-w-4xl gap-6 sm:grid-cols-2">
-        <Link
-          to="/predict"
-          className="group rounded-lg border border-gray-200 bg-white p-6 transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
-        >
-          <div className="mb-4 text-4xl" aria-hidden="true">🔍</div>
-          <h3 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
-            Faire une prédiction
+      <section className="grid gap-8 lg:grid-cols-3">
+        <div className="rounded-2xl border border-yellow-200/60 bg-white/80 p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-yellow-500/30 dark:bg-gray-900/70">
+          <h3 className="mb-3 flex items-center gap-3 text-lg font-semibold text-gray-900 dark:text-yellow-50">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-yellow-100 text-2xl dark:bg-yellow-500/30">📸</span>
+            Capture express
           </h3>
-          <p className="text-gray-600 dark:text-gray-400">
-            Uploadez une image ou prenez une photo pour obtenir une prédiction de maturité
+          <p className="text-sm leading-6 text-gray-600 dark:text-yellow-100/90">
+            Importez une image ou prenez une photo depuis votre appareil. Nous avons optimisé le flux pour qu&apos;il soit clair, rapide et adapté mobile.
           </p>
-        </Link>
-
-        <Link
-          to="/settings"
-          className="group rounded-lg border border-gray-200 bg-white p-6 transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
-        >
-          <div className="mb-4 text-4xl" aria-hidden="true">⚙️</div>
-          <h3 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
-            Paramètres
-          </h3>
-          <p className="text-gray-600 dark:text-gray-400">
-            Configurez l&apos;URL du backend et les endpoints de l&apos;API
-          </p>
-        </Link>
-      </div>
-
-      <div className="mx-auto max-w-2xl rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
-        <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
-          Documentation
-        </h2>
-        <div className="space-y-3 text-sm text-gray-600 dark:text-gray-400">
-          <p>
-            Cette application permet d&apos;interagir avec un backend FastAPI pour la prédiction de maturité des bananes.
-          </p>
-          <ul className="list-inside list-disc space-y-1">
-            <li>Uploadez une image depuis votre appareil ou prenez une photo</li>
-            <li>Obtenez une prédiction avec un score de confiance</li>
-            <li>Soumettez des corrections pour améliorer le modèle</li>
-            <li>Configurez les paramètres de connexion au backend</li>
-          </ul>
         </div>
-      </div>
+        <div className="rounded-2xl border border-yellow-200/60 bg-white/80 p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-yellow-500/30 dark:bg-gray-900/70">
+          <h3 className="mb-3 flex items-center gap-3 text-lg font-semibold text-gray-900 dark:text-yellow-50">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-yellow-100 text-2xl dark:bg-yellow-500/30">🧠</span>
+            Analyse guidée
+          </h3>
+          <p className="text-sm leading-6 text-gray-600 dark:text-yellow-100/90">
+            L&apos;IA évalue le stade de maturité et vous présente un score de confiance lisible, avec une palette couleurs accessible et contrastée.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-yellow-200/60 bg-white/80 p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-yellow-500/30 dark:bg-gray-900/70">
+          <h3 className="mb-3 flex items-center gap-3 text-lg font-semibold text-gray-900 dark:text-yellow-50">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-yellow-100 text-2xl dark:bg-yellow-500/30">💬</span>
+            Boucle d&apos;amélioration
+          </h3>
+          <p className="text-sm leading-6 text-gray-600 dark:text-yellow-100/90">
+            Soumettez vos corrections pour renforcer le modèle et maintenir votre stock de bananes à point.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
+        <div className="rounded-3xl border border-yellow-200/60 bg-white/80 p-8 shadow-lg dark:border-yellow-500/30 dark:bg-gray-900/70">
+          <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-yellow-50">Pourquoi ce mini-site ?</h2>
+          <p className="text-sm leading-7 text-gray-600 dark:text-yellow-100/90">
+            Banana Prediction est né d&apos;un besoin tout simple : suivre la maturité des bananes pour éviter le gaspillage alimentaire et servir les meilleures bananes dans nos préparations. Ce mini-site est une petite lettre d&apos;amour aux bananes mûries à point et aux interfaces solaires.
+          </p>
+          <p className="mt-4 text-sm leading-7 text-gray-600 dark:text-yellow-100/90">
+            Ici on raconte notre histoire, on partage les expériences et on offre une porte d&apos;entrée ludique vers les prédictions tropicales.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-yellow-200/60 bg-white/80 p-8 shadow-lg dark:border-yellow-500/30 dark:bg-gray-900/70">
+          <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-yellow-50">L&apos;humeur du verger</h2>
+          <div className="space-y-5 text-sm leading-7 text-gray-600 dark:text-yellow-100/90">
+            <div className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-2xl bg-yellow-100 text-xl dark:bg-yellow-500/30">🍯</span>
+              <p>
+                Des bananes flambées pour célébrer nos réussites UI et garder la flamme créative allumée.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-2xl bg-yellow-100 text-xl dark:bg-yellow-500/30">🎨</span>
+              <p>
+                Une palette ensoleillée, des icônes pixel art et des micro-animations qui apportent du sourire sans le jargon des standards.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-2xl bg-yellow-100 text-xl dark:bg-yellow-500/30">🪴</span>
+              <p>
+                On cultive le projet à l&apos;instinct : feedbacks, tests et une bonne dose de soleil pour que l&apos;IHM reste vivante.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -16,6 +16,18 @@ export default {
           800: '#31425e',
           900: '#2c3950',
         },
+        banana: {
+          50: '#fffbea',
+          100: '#fff3c4',
+          200: '#fce588',
+          300: '#fadb5f',
+          400: '#f7c948',
+          500: '#f0b429',
+          600: '#de911d',
+          700: '#c16a0a',
+          800: '#9c4810',
+          900: '#6b3410',
+        },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary
- remove the standards and documentation panels from the banana home page
- focus the secondary section on project storytelling and playful mood highlights that fit the banana theme

## Testing
- npm run build *(fails: missing local Vitest type definitions because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4fa9d31f883329dcf720fd2e442a4